### PR TITLE
Initialize the getpw_r buffer before passing it to the C API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,17 +123,16 @@ where
     let mut passwd = unsafe { mem::zeroed() };
     let amt = unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) };
     let mut amt = libc::c_long::max(amt, 512) as usize;
-    let mut buf = Vec::with_capacity(amt);
+    let mut buf = vec![0; amt];
 
     loop {
-        buf.reserve(amt);
         let mut result = ptr::null_mut();
         unsafe {
             f(
                 key,
                 &mut passwd,
                 buf.as_mut_ptr(),
-                buf.capacity(),
+                buf.len(),
                 &mut result,
             );
         }
@@ -152,6 +151,7 @@ where
             // Insufficient buffer space
             libc::ERANGE => {
                 amt *= 2;
+                buf.resize(amt, 0);
                 continue;
             }
 


### PR DESCRIPTION
~The use of `Vec::reserve` is not correct. It does not actually reallocate the buffer in this case. See the documentation of `Vec::reserve`
https://doc.rust-lang.org/std/vec/struct.Vec.html#method.reserve~

~After calling reserve, capacity will be greater than or equal to self.len() + additional.~

~But `self.len()` is always zero, because it is only ever attempted to set the capacity not the len.~

~This problem will result in an infinite loop in case of required reallocation.~

~Fix this by actually resizing and therefore increasing `self.len()`. This has the downside of requireing initialization of the buffer content. But I think it is a good idea to initialize the buffer before passing it to the C function. We also do that for `struct passwd` already.~

See discussion below.