### PR TITLE
Fix for macos build - don't unpack passwd fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,23 +86,14 @@ impl Passwd {
     }
 
     unsafe fn from_c_struct(passwd: &libc::passwd) -> Self {
-        let libc::passwd {
-            pw_name,
-            pw_passwd,
-            pw_uid,
-            pw_gid,
-            pw_gecos,
-            pw_dir,
-            pw_shell,
-        } = *passwd;
         Self {
-            name: CStr::from_ptr(pw_name).to_owned(),
-            passwd: CStr::from_ptr(pw_passwd).to_owned(),
-            uid: pw_uid,
-            gid: pw_gid,
-            gecos: CStr::from_ptr(pw_gecos).to_owned(),
-            dir: CStr::from_ptr(pw_dir).to_owned(),
-            shell: CStr::from_ptr(pw_shell).to_owned(),
+            name: CStr::from_ptr(passwd.pw_name).to_owned(),
+            passwd: CStr::from_ptr(passwd.pw_passwd).to_owned(),
+            uid: passwd.pw_uid,
+            gid: passwd.pw_gid,
+            gecos: CStr::from_ptr(passwd.pw_gecos).to_owned(),
+            dir: CStr::from_ptr(passwd.pw_dir).to_owned(),
+            shell: CStr::from_ptr(passwd.pw_shell).to_owned(),
         }
     }
 }
@@ -174,7 +165,10 @@ mod test {
         assert_eq!(by_name.uid, 0);
         assert_eq!(by_name.gid, 0);
         assert_eq!(by_name.name.to_str()?, "root");
+        #[cfg(not(target_os = "macos"))]
         assert_eq!(by_name.dir.to_str()?, "/root");
+        #[cfg(target_os = "macos")]
+        assert_eq!(by_name.dir.to_str()?, "/var/root");
 
         assert_eq!(by_uid, by_name);
 


### PR DESCRIPTION
Addresses: https://github.com/gifnksm/etc-passwd/issues/3

Since the `libc::passwd` struct contains different fields on MacOS vs Linux variants, unpacking into the expected fields for Linux on Mac raises a compile error. We can get around this by using the fields directly, which are common between the two platforms.

We'd like to use the MIT license for this contribution:
> Copyright (c) 2020 NAKASHIMA, Makoto
> 
> Permission is hereby granted, free of charge, to any person obtaining a copy
> of this software and associated documentation files (the "Software"), to deal
> in the Software without restriction, including without limitation the rights
> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
> copies of the Software, and to permit persons to whom the Software is
> furnished to do so, subject to the following conditions:
> 
> The above copyright notice and this permission notice shall be included in all
> copies or substantial portions of the Software.
> 
> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
> SOFTWARE.